### PR TITLE
fix(notice): fix goDetail error

### DIFF
--- a/src/layouts/components/Notice.vue
+++ b/src/layouts/components/Notice.vue
@@ -53,6 +53,7 @@ import { NotificationItem } from '@/interface';
 
 export default defineComponent({
   setup() {
+    const router = useRouter();
     const store = useStore();
     const { msgData } = store.state.notification;
 
@@ -75,7 +76,6 @@ export default defineComponent({
     };
 
     const goDetail = () => {
-      const router = useRouter();
       router.push('/detail/secondary');
     };
 


### PR DESCRIPTION
修复通知中点击 "查看全部"，router为undefined导致的无法跳转问题。