### PR TITLE
优化菜单选中判断逻辑

### DIFF
--- a/src/layouts/components/Header.vue
+++ b/src/layouts/components/Header.vue
@@ -65,8 +65,9 @@
 
 <script setup lang="ts">
 import { PropType, computed } from 'vue';
-import { useRouter, useRoute } from 'vue-router';
+import { useRouter } from 'vue-router';
 import { useSettingStore } from '@/store';
+import { getActive } from '@/router';
 import { prefix } from '@/config/global';
 import tLogoFull from '@/assets/assets-logo-full.svg?component';
 import { MenuRoute } from '@/interface';
@@ -115,18 +116,7 @@ const toggleSettingPanel = () => {
   });
 };
 
-const active = computed(() => {
-  const { layout } = props;
-  const route = useRoute();
-  if (!route.path) {
-    return '';
-  }
-  return route.path
-    .split('/')
-    .filter((item, index) => index < props.maxLevel - (layout === 'mix' ? 1 : -1) && index > 0)
-    .map((item) => `/${item}`)
-    .join('');
-});
+const active = computed(() => getActive());
 
 const layoutCls = computed(() => [`${prefix}-header-layout`]);
 

--- a/src/layouts/components/SideNav.tsx
+++ b/src/layouts/components/SideNav.tsx
@@ -1,16 +1,19 @@
 import { defineComponent, PropType, computed, onMounted } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRouter } from 'vue-router';
 import { prefix } from '@/config/global';
 import pgk from '../../../package.json';
 import MenuContent from './MenuContent';
 import tLogo from '@/assets/assets-t-logo.svg?component';
 import tLogoFull from '@/assets/assets-logo-full.svg?component';
 import { useSettingStore } from '@/store';
+import { getActive } from '@/router';
 
 const MIN_POINT = 992 - 1;
 
 const useComputed = (props) => {
   const collapsed = computed(() => useSettingStore().isSidebarCompact);
+
+  const active = computed(() => getActive());
 
   const sideNavCls = computed(() => {
     const { isCompact } = props;
@@ -40,6 +43,7 @@ const useComputed = (props) => {
   });
 
   return {
+    active,
     collapsed,
     sideNavCls,
     menuCls,
@@ -107,18 +111,6 @@ export default defineComponent({
       };
     });
 
-    const getActiveName = (maxLevel = 2) => {
-      const route = useRoute();
-      if (!route.path) {
-        return '';
-      }
-      return route.path
-        .split('/')
-        .filter((_item: string, index: number) => index <= maxLevel && index > 0)
-        .map((item: string) => `/${item}`)
-        .join('');
-    };
-
     const goHome = () => {
       router.push('/dashboard/base');
     };
@@ -128,18 +120,16 @@ export default defineComponent({
       ...useComputed(props),
       autoCollapsed,
       changeCollapsed,
-      getActiveName,
       goHome,
     };
   },
   render() {
-    const active = this.getActiveName();
     return (
       <div class={this.sideNavCls}>
         <t-menu
           class={this.menuCls}
           theme={this.theme}
-          value={active}
+          value={this.active}
           collapsed={this.collapsed}
           v-slots={{
             logo: () =>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
+import { useRoute, createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
 
 import baseRouters from './modules/base';
 import componentsRouters from './modules/components';
@@ -29,6 +29,18 @@ const defaultRouterList: Array<RouteRecordRaw> = [
 ];
 
 export const allRoutes = [...defaultRouterList, ...asyncRouterList];
+
+export const getActive = (maxLevel = 2): string => {
+  const route = useRoute();
+  if (!route.path) {
+    return '';
+  }
+  return route.path
+    .split('/')
+    .filter((_item: string, index: number) => index <= maxLevel && index > 0)
+    .map((item: string) => `/${item}`)
+    .join('');
+};
 
 const router = createRouter({
   history: createWebHashHistory(),


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
暂无相关issue
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
```json
{
    path: '/module1',
    component: Layout,
    redirect: '/module1/list',
    name: 'MODULE1',
    meta: { title: '模块1', icon: ListIcon, single: true },
    children: [
      {
        path: 'list',
        name: 'MODULE1_LIST',
        component: () => import('@/pages/module1/list/index.vue'),
        meta: { title: '列表页' },
      },
      {
        path: 'view',
        name: 'MODULE1_VIEW',
        component: () => import('@/pages/module1/view/index.vue'),
        meta: { title: '详情页' },
      },
      {
        path: 'edit',
        name: 'MODULE1_EDIT',
        component: () => import('@/pages/module1/edit/index.vue'),
        meta: { title: '编辑页' },
      },
    ],
}
```
当遇到以上的路由配置时，现有的实现方案就会出现：路由到【详情页或编辑页】时，父菜单没有加上选中态样式；
解决方案：
* 优化代码，将之前两处重复的代码逻辑迁移至路由模块，去除冗余代码
* 新增逻辑，如果当前选中的路由属于某一父菜单，则将该父菜单的value值设为当前路由，这样就能统一处理以上配置或之前分隔菜单带来的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(Menu): 统一处理激活菜单样式问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
