### PR TITLE
feat(sidenav): add default expanded

### DIFF
--- a/src/layouts/components/SideNav.tsx
+++ b/src/layouts/components/SideNav.tsx
@@ -15,6 +15,12 @@ const useComputed = (props) => {
 
   const active = computed(() => getActive());
 
+  const defaultExpanded = computed(() => {
+    const path = getActive();
+    const parentPath = path.substring(0, path.lastIndexOf('/'));
+    return parentPath === '' ? [] : [parentPath];
+  });
+
   const sideNavCls = computed(() => {
     const { isCompact } = props;
     return [
@@ -44,6 +50,7 @@ const useComputed = (props) => {
 
   return {
     active,
+    defaultExpanded,
     collapsed,
     sideNavCls,
     menuCls,
@@ -130,6 +137,7 @@ export default defineComponent({
           class={this.menuCls}
           theme={this.theme}
           value={this.active}
+          default-expanded={this.defaultExpanded}
           collapsed={this.collapsed}
           v-slots={{
             logo: () =>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 演示代码改进

### 💡 需求背景和解决方案

1. 当前Starter演示项目中，在页面刷新后、通过URL直接访问等场景下，导航菜单不会按照当前激活的子菜单情况展开，使用上会比较迷惑。
2. 增加了一个通过当前激活菜单构造menu defaultExpanded的方法解决这个问题。

### 📝 更新日志

- feat(sidenav): 增加导航菜单在URL访问和刷新场景下的的默认展开

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
