### PR TITLE
feat: tabs-router 支持存储路由的query，保证切换tab时，能保留页面参数

### DIFF
--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -63,10 +63,11 @@ export default defineComponent({
     const appendNewRoute = () => {
       const {
         path,
+        query,
         meta: { title },
         name,
       } = route;
-      tabsRouterStore.appendTabRouterList({ path, title: title as string, name, isAlive: true });
+      tabsRouterStore.appendTabRouterList({ path, query, title: title as string, name, isAlive: true });
     };
 
     const getTabRouterListCache = () => {
@@ -103,29 +104,31 @@ export default defineComponent({
       const { tabRouters } = tabsRouterStore;
       const nextRouter = tabRouters[index + 1] || tabRouters[index - 1];
 
-      tabsRouterStore.subtractCurrentTabRouter({ path, routeIdx: index });
+      tabsRouterStore.subtractCurrentTabRouter({ path, query: null, routeIdx: index });
       if (path === route.path) {
-        router.push(nextRouter.path);
+        router.push({ path: nextRouter.path, query: nextRouter.query });
       }
     };
     const handleChangeCurrentTab = (path: string) => {
-      router.push(path);
+      const { tabRouters } = tabsRouterStore;
+      const route = tabRouters.find((i) => i.path === path);
+      router.push({ path, query: route.query });
     };
-    const handleRefresh = (currentPath: string, routeIdx: number) => {
-      tabsRouterStore.toggleTabRouterAlive(routeIdx);
+    const handleRefresh = (route: TRouterInfo) => {
+      tabsRouterStore.toggleTabRouterAlive(route.routeIdx);
       nextTick(() => {
-        tabsRouterStore.toggleTabRouterAlive(routeIdx);
-        router.replace({ path: currentPath });
+        tabsRouterStore.toggleTabRouterAlive(route.routeIdx);
+        router.replace({ path: route.path, query: route.query });
       });
     };
     const handleCloseAhead = (path: string, routeIdx: number) => {
-      tabsRouterStore.subtractTabRouterAhead({ path, routeIdx });
+      tabsRouterStore.subtractTabRouterAhead({ path, query: null, routeIdx });
     };
     const handleCloseBehind = (path: string, routeIdx: number) => {
-      tabsRouterStore.subtractTabRouterBehind({ path, routeIdx });
+      tabsRouterStore.subtractTabRouterBehind({ path, query: null, routeIdx });
     };
     const handleCloseOther = (path: string, routeIdx: number) => {
-      tabsRouterStore.subtractTabRouterOther({ path, routeIdx });
+      tabsRouterStore.subtractTabRouterOther({ path, query: null, routeIdx });
     };
 
     const renderSidebar = () => {
@@ -195,7 +198,7 @@ export default defineComponent({
                           dropdown: () =>
                             router.path === route.path ? (
                               <t-dropdown-menu>
-                                <t-dropdown-item onClick={() => handleRefresh(router.path, idx)}>
+                                <t-dropdown-item onClick={() => handleRefresh(router)}>
                                   <t-icon name="refresh" />
                                   刷新
                                 </t-dropdown-item>

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -104,7 +104,7 @@ export default defineComponent({
       const { tabRouters } = tabsRouterStore;
       const nextRouter = tabRouters[index + 1] || tabRouters[index - 1];
 
-      tabsRouterStore.subtractCurrentTabRouter({ path, query: null, routeIdx: index });
+      tabsRouterStore.subtractCurrentTabRouter({ path, routeIdx: index });
       if (path === route.path) {
         router.push({ path: nextRouter.path, query: nextRouter.query });
       }
@@ -122,13 +122,13 @@ export default defineComponent({
       });
     };
     const handleCloseAhead = (path: string, routeIdx: number) => {
-      tabsRouterStore.subtractTabRouterAhead({ path, query: null, routeIdx });
+      tabsRouterStore.subtractTabRouterAhead({ path, routeIdx });
     };
     const handleCloseBehind = (path: string, routeIdx: number) => {
-      tabsRouterStore.subtractTabRouterBehind({ path, query: null, routeIdx });
+      tabsRouterStore.subtractTabRouterBehind({ path, routeIdx });
     };
     const handleCloseOther = (path: string, routeIdx: number) => {
-      tabsRouterStore.subtractTabRouterOther({ path, query: null, routeIdx });
+      tabsRouterStore.subtractTabRouterOther({ path, routeIdx });
     };
 
     const renderSidebar = () => {

--- a/src/store/modules/tabs-router.ts
+++ b/src/store/modules/tabs-router.ts
@@ -5,6 +5,7 @@ import { store } from '@/store';
 const homeRoute: Array<TRouterInfo> = [
   {
     path: '/dashboard/base',
+    query: null,
     routeIdx: 0,
     title: '仪表盘',
     name: 'DashboardBase',

--- a/src/store/modules/tabs-router.ts
+++ b/src/store/modules/tabs-router.ts
@@ -5,7 +5,6 @@ import { store } from '@/store';
 const homeRoute: Array<TRouterInfo> = [
   {
     path: '/dashboard/base',
-    query: null,
     routeIdx: 0,
     title: '仪表盘',
     name: 'DashboardBase',

--- a/src/types/interface.d.ts
+++ b/src/types/interface.d.ts
@@ -36,7 +36,7 @@ export interface NotificationItem {
 
 export interface TRouterInfo {
   path: string;
-  query: LocationQueryRaw;
+  query?: LocationQueryRaw;
   routeIdx?: number;
   title?: string;
   name?: RouteRecordName;

--- a/src/types/interface.d.ts
+++ b/src/types/interface.d.ts
@@ -36,6 +36,7 @@ export interface NotificationItem {
 
 export interface TRouterInfo {
   path: string;
+  query: LocationQueryRaw;
   routeIdx?: number;
   title?: string;
   name?: RouteRecordName;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [X] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

如某一路由带有重要参数时，切换其他标签重新切换回来后，参数丢失。
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

让tabs-router支持存储路由query，以保留页面参数，来回切换tab后不丢失路由参数。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- feat: Tabs新增存储路由的query参数

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
