### PR TITLE
fix: 修复浏览器不兼容页中浏览器推荐卡片遮挡页脚信息问题

### DIFF
--- a/src/pages/result/browser-incompatible/index.vue
+++ b/src/pages/result/browser-incompatible/index.vue
@@ -38,14 +38,14 @@ import Thumbnail from '@/components/thumbnail/index.vue';
   align-items: center;
   justify-content: space-between;
   color: var(--td-text-color-secondary);
+  height: calc(75vh - 254px);
+  min-height: 156px;
 }
 
 .recommend-container {
-  position: absolute;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  top: 175px;
   padding: 24px 48px;
   width: 640px;
   background: var(--td-bg-color-container);


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

`推荐浏览器` 卡片在响应式（变更浏览器高度）时，显示效果不好。

考虑到 `result` 样式问题，删除了 `返回首页` 按钮，既然浏览器不兼容，那么返回首页也一样不兼容。

|修改前|修改后|
|  ----  | ----  |
|![image](https://user-images.githubusercontent.com/487040/189090554-6f224b16-3b60-46d8-9086-bb9aea8023b0.png)|![image](https://user-images.githubusercontent.com/487040/189317032-b401a1dc-b24d-4961-ab7e-bae9e7e200fa.png)|

### 📝 更新日志

- fix: 修复浏览器不兼容页中浏览器推荐卡片遮挡页脚信息问题

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
