### PR TITLE
修复重置路由时，二级嵌套路由被当成一级路由添加时的报错问题

### DIFF
--- a/src/store/modules/permission.ts
+++ b/src/store/modules/permission.ts
@@ -53,7 +53,7 @@ export const usePermissionStore = defineStore('permission', {
       this.removeRoutes = removeRoutes;
 
       removeRoutes.forEach((item: RemoveRouteInfo) => {
-        if (router.hasRoute(item.parentRouteName)) {
+        if (router.hasRoute(item.route.name)) {
           router.removeRoute(item.route.name);
         }
       });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
[权限相关] 非roles: ['all']的情况下 会出现paths should start with a "/": "add" should be "/add"

https://github.com/Tencent/tdesign-vue-next-starter/issues/352

### 💡 需求背景和解决方案
问题：重置路由addRoutes问题
方案：添加路由时指定一级parent路由

### 📝 更新日志

修复路由重置时添加路由失败问题

- fix(组件名称): store/modules/permission.ts

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
