### PR TITLE
fix: 修复 store 中并未对 localStorage 的 TOKEN_NAME 键进行赋值的缺陷

### DIFF
--- a/src/permission.ts
+++ b/src/permission.ts
@@ -4,6 +4,7 @@ import NProgress from 'nprogress'; // progress bar
 import { MessagePlugin } from 'tdesign-vue-next';
 import { RouteRecordRaw } from 'vue-router';
 
+import { TOKEN_NAME } from '@/config/global';
 import router from '@/router';
 import { getPermissionStore, getUserStore } from '@/store';
 import { PAGE_NOT_FOUND_ROUTE } from '@/utils/route/constant';
@@ -17,8 +18,8 @@ router.beforeEach(async (to, from, next) => {
   const { whiteListRouters } = permissionStore;
 
   const userStore = getUserStore();
-  const { token } = userStore;
-  if (token) {
+
+  if (userStore[TOKEN_NAME]) {
     if (to.path === '/login') {
       next();
       return;

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -49,7 +49,7 @@ export const useUserStore = defineStore('user', {
 
       const res = await mockLogin(userInfo);
       if (res.code === 200) {
-        this.token = res.data;
+        this.setToken(res.data);
       } else {
         throw res;
       }
@@ -72,12 +72,16 @@ export const useUserStore = defineStore('user', {
       this.userInfo = res;
     },
     async logout() {
-      localStorage.removeItem(TOKEN_NAME);
-      this.token = '';
+      this.removeToken();
       this.userInfo = { ...InitUserInfo };
     },
     async removeToken() {
-      this.token = '';
+      localStorage.removeItem(TOKEN_NAME);
+      this.setToken('');
+    },
+    async setToken(token: string) {
+      this.token = token;
+      localStorage.setItem(TOKEN_NAME, this.token);
     },
   },
   persist: {

--- a/src/store/modules/user.ts
+++ b/src/store/modules/user.ts
@@ -10,7 +10,7 @@ const InitUserInfo = {
 
 export const useUserStore = defineStore('user', {
   state: () => ({
-    token: localStorage.getItem(TOKEN_NAME) || 'main_token', // 默认token不走权限
+    [TOKEN_NAME]: 'main_token', // 默认token不走权限
     userInfo: { ...InitUserInfo },
   }),
   getters: {
@@ -67,7 +67,7 @@ export const useUserStore = defineStore('user', {
           roles: ['UserIndex', 'DashboardBase', 'login'], // 前端权限模型使用 如果使用请配置modules/permission-fe.ts使用
         };
       };
-      const res = await mockRemoteUserInfo(this.token);
+      const res = await mockRemoteUserInfo(this[TOKEN_NAME]);
 
       this.userInfo = res;
     },
@@ -76,12 +76,10 @@ export const useUserStore = defineStore('user', {
       this.userInfo = { ...InitUserInfo };
     },
     async removeToken() {
-      localStorage.removeItem(TOKEN_NAME);
       this.setToken('');
     },
     async setToken(token: string) {
-      this.token = token;
-      localStorage.setItem(TOKEN_NAME, this.token);
+      this[TOKEN_NAME] = token;
     },
   },
   persist: {
@@ -89,6 +87,8 @@ export const useUserStore = defineStore('user', {
       const permissionStore = usePermissionStore();
       permissionStore.initRoutes();
     },
+    key: 'user',
+    paths: [TOKEN_NAME],
   },
 });
 

--- a/src/utils/request/index.ts
+++ b/src/utils/request/index.ts
@@ -116,7 +116,6 @@ const transform: AxiosTransform = {
     // 请求之前处理config
     const userStore = getUserStore();
     const token = userStore[TOKEN_NAME];
-    console.log('token', token);
 
     if (token && (config as Recordable)?.requestOptions?.withToken !== false) {
       // jwt token

--- a/src/utils/request/index.ts
+++ b/src/utils/request/index.ts
@@ -5,6 +5,7 @@ import merge from 'lodash/merge';
 
 import { TOKEN_NAME } from '@/config/global';
 import { ContentTypeEnum } from '@/constants';
+import { getUserStore } from '@/store';
 
 import { VAxios } from './Axios';
 import type { AxiosTransform, CreateAxiosOptions } from './AxiosTransform';
@@ -113,7 +114,10 @@ const transform: AxiosTransform = {
   // 请求拦截器处理
   requestInterceptors: (config, options) => {
     // 请求之前处理config
-    const token = localStorage.getItem(TOKEN_NAME);
+    const userStore = getUserStore();
+    const token = userStore[TOKEN_NAME];
+    console.log('token', token);
+
     if (token && (config as Recordable)?.requestOptions?.withToken !== false) {
       // jwt token
       (config as Recordable).headers.Authorization = options.authenticationScheme


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 底层携带`token`从`localStorage`中获取`token`，而`store`中并未对`localStorage`的`TOKEN_NAME`键进行赋值，`sotore`做了持久化，亦可修改下面的获取方式从`userStore`中获取
![image](https://github.com/Tencent/tdesign-vue-next-starter/assets/22363718/77c81d89-7794-4ea6-8946-c80a87c9de81)

2. 另外，这里默认开启`withCredentials`则在跨域请求时对后端的安全性要求更高，强制要求`Access-Control-Allow-Origin`必须返回当前域，`axios`组件该参数默认貌似是关闭的，是否应该当开发者明确自己的需求必须携带cookie时主动打开该配置，而不是默认开启，因为大部分项目应该不需要携带cookie。
![image](https://github.com/Tencent/tdesign-vue-next-starter/assets/22363718/99c30e39-796e-4116-8a3a-1b37212a8186)

以上属于个人简单测试后的拙见，仅供参考

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: 修复 store 中并未对 localStorage 的 TOKEN_NAME 键进行赋值的缺陷

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
