### PR TITLE
fix: 修复路由切换时过渡动画异常的问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <t-config-provider :global-config="getComponentsLocale">
-    <router-view :key="locale" :class="[mode]"
-  /></t-config-provider>
+    <router-view :key="locale" :class="[mode]" />
+  </t-config-provider>
 </template>
 <script setup lang="ts">
 import { computed } from 'vue';

--- a/src/layouts/components/Content.vue
+++ b/src/layouts/components/Content.vue
@@ -1,6 +1,6 @@
 <template>
   <router-view v-if="!isRefreshing" v-slot="{ Component }">
-    <transition name="fade">
+    <transition name="fade" mode="out-in">
       <keep-alive :include="aliveViews">
         <component :is="Component" />
       </keep-alive>
@@ -54,7 +54,7 @@ const isRefreshing = computed(() => {
   transition: opacity @anim-duration-slow @anim-time-fn-easing;
 }
 
-.fade-enter,
+.fade-enter-from,
 .fade-leave-to {
   opacity: 0;
 }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

![20240115_144304](https://github.com/Tencent/tdesign-vue-next-starter/assets/6757507/82b0d7de-f1a9-495d-a37a-e9b44b1ca31f)

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

- Vue3 修改了[过渡效果的类名](https://cn.vuejs.org/guide/built-ins/transition.html#named-transitions) `.fade-enter` -> `.fade-enter-from` 
- `transition` 组件未添加 `mode="out-in"`

### 📝 更新日志

- fix(starter): 修复路由切换时过渡动画异常的问题

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
