### PR TITLE
fix: 修复ECharts环形图文字重叠的问题

### DIFF
--- a/src/pages/dashboard/base/components/MiddleChart.vue
+++ b/src/pages/dashboard/base/components/MiddleChart.vue
@@ -97,6 +97,25 @@ const renderCountChart = () => {
   }
   countChart = echarts.init(countContainer);
   countChart.setOption(getPieChartDataSet(chartColors.value));
+
+  // 取消之前高亮的图形
+  countChart.dispatchAction({
+    type: 'downplay',
+    seriesIndex: 0,
+    dataIndex: -1,
+  });
+  // 高亮当前图形
+  countChart.dispatchAction({
+    type: 'highlight',
+    seriesIndex: 0,
+    dataIndex: 1,
+  });
+  // 显示 tooltip
+  countChart.dispatchAction({
+    type: 'showTip',
+    seriesIndex: 0,
+    dataIndex: 1,
+  });
 };
 
 const renderCharts = () => {

--- a/src/pages/dashboard/base/index.ts
+++ b/src/pages/dashboard/base/index.ts
@@ -368,7 +368,6 @@ export function getPieChartDataSet({
           scale: true,
           label: {
             show: false,
-            // formatter: ['{value|{d}%}', '{name|{b}渠道占比}'].join('\n'), 就是这个东西造成文字重叠
             rich: {
               value: {
                 color: textColor,

--- a/src/pages/dashboard/base/index.ts
+++ b/src/pages/dashboard/base/index.ts
@@ -367,8 +367,8 @@ export function getPieChartDataSet({
         emphasis: {
           scale: true,
           label: {
-            show: true,
-            formatter: ['{value|{d}%}', '{name|{b}渠道占比}'].join('\n'),
+            show: false,
+            // formatter: ['{value|{d}%}', '{name|{b}渠道占比}'].join('\n'), 就是这个东西造成文字重叠
             rich: {
               value: {
                 color: textColor,


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
link #555 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

Dev模式下显示正常但在Preview模式下会出现环形图内标签文字重叠的问题。
![image](https://github.com/Tencent/tdesign-vue-next-starter/assets/36812439/7b434901-09d0-4d69-ac53-711ff298e507)

而ECharts官方对此问题的建议是不要将标签设置在环形图内，包括官方示例列表中也没有该类示例
[相关Issue](https://github.com/apache/echarts/issues/18119)

⚠️ **请注意：** 因为如果开放用户自由选择会导致标签再次重叠，因此默认禁用，暂时无解⚠️
![output](https://github.com/Tencent/tdesign-vue-next-starter/assets/36812439/a94c8472-379e-4fcb-b490-ec6b0686ae9d)

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: 修复ECharts环形图文字重叠的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
