### PR TITLE
feat(Router): 路由跳转携带参数

### DIFF
--- a/src/permission.ts
+++ b/src/permission.ts
@@ -39,7 +39,7 @@ router.beforeEach(async (to, from, next) => {
           next({ path: to.fullPath, replace: true, query: to.query });
         } else {
           const redirect = decodeURIComponent((from.query.redirect || to.path) as string);
-          next(to.path === redirect ? { ...to, replace: true } : { path: redirect });
+          next(to.path === redirect ? { ...to, replace: true } : { path: redirect, query: to.query });
           return;
         }
       }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

当链接为/sale/custom/info?id=996这类带get参数退出再登录时，不能正确的带着参数进行跳转
应当将query合并进来，方可正常跳转

### 💡 需求背景和解决方案

带get参数时能正常跳转

### 📝 更新日志

- feat(Router): 路由跳转携带参数

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充
- [X] Changelog 已提供或无须提供
