### PR TITLE
refactor(i18n): 优化国际化配置并添加类型注解

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage, usePreferredLanguages } from '@vueuse/core';
 import { DropdownOption } from 'tdesign-vue-next';
 import { computed } from 'vue';
-import { createI18n } from 'vue-i18n';
+import { createI18n, I18nOptions } from 'vue-i18n';
 
 // 导入语言文件
 const langModules = import.meta.glob('./lang/*/index.ts', { eager: true });
@@ -43,7 +43,7 @@ export const i18n = createI18n({
   legacy: false,
   locale: useLocalStorage(localeConfigKey, 'zh_CN').value || languages.value[0] || 'zh_CN',
   fallbackLocale: 'zh_CN',
-  messages: importMessages.value,
+  messages: importMessages.value as I18nOptions['messages'],
   globalInjection: true,
 });
 


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 相关issue

#648 

### 💡 需求背景和解决方案

1. vscode编辑中，在ts中直接使用t('xx.xx.xx.xx.xx')时会报“类型实例化过深，且可能无限”。
2. 通过在国际化配置中添加类型注解，消除此报警。

### 📝 更新日志

- refactor(i18n): 优化国际化配置并添加类型注解，修复后续在ts定义文件中直接使用“t('xx.xx.xx.xx')”时编辑器报“类型实例化过深，且可能无限”的警告

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供