### PR TITLE
feat: 修复列表树搜索后无法收起展开问题(#807)

### DIFF
--- a/src/pages/list/tree/index.vue
+++ b/src/pages/list/tree/index.vue
@@ -35,6 +35,10 @@ const filterText = ref();
 const expanded = ['0', '0-0', '0-1', '0-2', '0-3', '0-4'];
 
 const onInput = () => {
+  if (!filterText.value) {
+    filterByText.value = null;
+    return;
+  }
   filterByText.value = (node: TreeNodeModel) => {
     return node.label.includes(filterText.value);
   };


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ✓] 日常 bug 修复

### 🔗 相关 Issue

https://github.com/Tencent/tdesign-vue-next-starter/issues/807

### 💡 需求背景和解决方案

https://github.com/user-attachments/assets/b0ca6cb0-94b7-4822-b615-28bdbfb1b758

### 📝 更新日志

如果list/tree搜索输入为空，则清除过滤条件对象。

### ☑️ 请求合并前的自查清单

- [ ✓] 文档已补充或无须补充
- [ ✓] 代码演示已提供或无须提供
- [ ✓] TypeScript 定义已补充或无须补充
- [ ✓] Changelog 已提供或无须提供
