### PR TITLE
fix(i18n): 修复 copyright 中 @ 导致 vue-i18n 编译报错 Invalid linked format

### DIFF
--- a/src/locales/lang/en_US.json
+++ b/src/locales/lang/en_US.json
@@ -2,7 +2,7 @@
   "lang": "English",
   "common": {
     "appName": "TDesign Starter",
-    "copyright": "Copyright @ 2021-2025 Tencent. All Rights Reserved",
+    "copyright": "Copyright © 2021-2025 Tencent. All Rights Reserved",
     "conjunction": "and",
     "admin": "admin"
   },

--- a/src/locales/lang/zh_CN.json
+++ b/src/locales/lang/zh_CN.json
@@ -2,7 +2,7 @@
   "lang": "简体中文",
   "common": {
     "appName": "TDesign Starter",
-    "copyright": "Copyright @ 2021-2025 Tencent. All Rights Reserved",
+    "copyright": "Copyright © 2021-2025 Tencent. All Rights Reserved",
     "conjunction": "和",
     "admin": "admin"
   },


### PR DESCRIPTION
将 @ 替换为 ©，避免 vue-i18n v11 的消息编译器将 @ 解析为 linked message 语法而报错。

<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
- https://github.com/Tencent/tdesign-vue-next-starter/issues/972
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix: 修复版权标识符导致编译错误的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
