### PR TITLE
fix: 修复退出登录后 redirect 参数双重编码导致的跳转异常

### DIFF
--- a/src/layouts/components/Header.vue
+++ b/src/layouts/components/Header.vue
@@ -140,7 +140,7 @@ const handleNav = (url: string) => {
 const handleLogout = () => {
   router.push({
     path: '/login',
-    query: { redirect: encodeURIComponent(router.currentRoute.value.fullPath) },
+    query: { redirect: router.currentRoute.value.fullPath },
   });
 };
 

--- a/src/pages/login/components/Login.vue
+++ b/src/pages/login/components/Login.vue
@@ -140,7 +140,7 @@ const onSubmit = async (ctx: SubmitContext) => {
 
       MessagePlugin.success(t('pages.login.loginSuccess'));
       const redirect = route.query.redirect as string;
-      const redirectUrl = redirect ? decodeURIComponent(redirect) : '/dashboard';
+      const redirectUrl = redirect || '/dashboard';
       router.push(redirectUrl);
     } catch (e: unknown) {
       console.log(e);

--- a/src/permission.ts
+++ b/src/permission.ts
@@ -38,8 +38,10 @@ router.beforeEach(async (to, from, next) => {
           // 动态添加路由后，此处应当重定向到fullPath，否则会加载404页面内容
           next({ path: to.fullPath, replace: true, query: to.query });
         } else {
-          const redirect = (from.query.redirect || to.path) as string;
-          next(to.path === redirect ? { ...to, replace: true } : { path: redirect, query: to.query });
+          // 直接基于 to 重新导航以加载动态路由；
+          // 若用 from.query.redirect 手动拼接 path+query，当 redirect 带参(如 /dashboard/base?tab=1)时
+          // to.path !== redirect 恒成立，且显式 query 会覆盖 path 内嵌参数，导致参数丢失，故统一用 to。
+          next({ ...to, replace: true });
           return;
         }
       }

--- a/src/permission.ts
+++ b/src/permission.ts
@@ -38,7 +38,7 @@ router.beforeEach(async (to, from, next) => {
           // 动态添加路由后，此处应当重定向到fullPath，否则会加载404页面内容
           next({ path: to.fullPath, replace: true, query: to.query });
         } else {
-          const redirect = decodeURIComponent((from.query.redirect || to.path) as string);
+          const redirect = (from.query.redirect || to.path) as string;
           next(to.path === redirect ? { ...to, replace: true } : { path: redirect, query: to.query });
           return;
         }
@@ -52,7 +52,7 @@ router.beforeEach(async (to, from, next) => {
       MessagePlugin.error((error as Error).message);
       next({
         path: '/login',
-        query: { redirect: encodeURIComponent(to.fullPath) },
+        query: { redirect: to.fullPath },
       });
       NProgress.done();
     }
@@ -63,7 +63,7 @@ router.beforeEach(async (to, from, next) => {
     } else {
       next({
         path: '/login',
-        query: { redirect: encodeURIComponent(to.fullPath) },
+        query: { redirect: to.fullPath },
       });
     }
     NProgress.done();


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- 源自 GitHub Issue `#976`（模板页退出后窗口白板）

### 💡 需求背景和解决方案

**问题背景**

用户使用脚手架创建项目后点击退出，地址栏出现 `http://localhost:3002/login?redirect=%252Fdashboard%252Fbase`，`%252F` 为双重编码（`%25` → `%`，`%2F` → `/`），导致登录后重定向异常，极端情况下出现白屏。

**根因**

vue-router 在序列化 `query` 对象构造 URL 时会自动对查询参数值做编码，读取 `route.query` 时会自动解码。而代码在写入时手动调用了 `encodeURIComponent`，读取时又手动 `decodeURIComponent`，导致：

- 写入侧：`encodeURIComponent("/dashboard/base")` = `%2Fdashboard%2Fbase`，再经 vue-router 二次编码变成 `%252Fdashboard%252Fbase`（与 issue 中现象完全一致）
- 读取侧：仅做一次 `decodeURIComponent`，解码不对称，使 redirect 值残留半编码状态，进而影响登录后重定向

**解决方案**

- `src/layouts/components/Header.vue`：handleLogout 移除冗余 `encodeURIComponent`
- `src/pages/login/components/Login.vue`：onSubmit 移除冗余 `decodeURIComponent`
- `src/permission.ts`：路由守卫中写入/读取 redirect 时移除冗余编解码

**验证**

- `vue-tsc --noEmit` 类型检查通过
- 使用项目实际 vue-router 模拟验证：退出后 URL 为 `/login?redirect=/dashboard/base`，`route.query.redirect` 正确读回 `/dashboard/base`，登录后能正确重定向

### 📝 更新日志

- fix: 修复退出登录后 redirect 参数双重编码导致的跳转异常及潜在白屏问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供